### PR TITLE
fix: invisible document name in light mode

### DIFF
--- a/resources/views/components/file-upload.blade.php
+++ b/resources/views/components/file-upload.blade.php
@@ -47,7 +47,7 @@
 
             <div class="uppy__files mt-2">
                 <template x-for="file in uploadedFiles" :key="file.name">
-                    <div class="uppy__file file py-2 px-4 text-sm text-white">
+                    <div class="uppy__file file py-2 px-4 text-sm dark:text-white">
                         <div>
                             <span class="file__name font-bold text-sm" x-text="file.name"></span>
                         </div>


### PR DESCRIPTION
### Contributor section

<!-- link to either the youtrack ticket or github issue if any -->

**YouTrack Issue: https://cloudmazing.myjetbrains.com/youtrack/issue/#**

**Fixes #0000**

**Changes**
<!-- brief description of the areas that have changed, and possibly a short reasoning of why 
    this implementation is preferred over alternatives -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->


<!-- add tests if appropriate, and make sure this is well tested, both on desktop and mobile -->
<!-- link to any other PRs related to this change if any -->
